### PR TITLE
Allow overriding of element value restore.

### DIFF
--- a/src/jquery.phoenix.coffee
+++ b/src/jquery.phoenix.coffee
@@ -78,7 +78,7 @@
     load: ->
       savedValue = localStorage[@storageKey]
       if savedValue?
-        @loadValues()
+        @loadValue()
         e = $.Event("phnx.loaded")
         @$element.trigger(e)
 


### PR DESCRIPTION
Hi,

I am using your plugin with Rails and the bootstrap-select gem does not play well with your plugin.

The gem creates a list from a select tag instead of using the default. Hence the restoration of data will not show up and I have to manually refresh it using their API. Hence I would like to be able to override the function to provide a custom callback.

I hope you can accept this soon. Thanks for your hard work on this plugin.
